### PR TITLE
Customisations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,9 @@ inputs:
   url:
     description: 'The URL for the vault endpoint'
     required: true
-  secrets:
-    description: 'A semicolon-separated list of secrets to retrieve. These will automatically be converted to environmental variable keys. See README for more details'
-    required: false
+  path:
+    description: 'The path to the secret, such as `/mysecrets/data/myapp/build`. Each key will be exported into its own environment variable.'
+    required: true
   namespace:
     description: 'The Vault namespace from which to query secrets. Vault Enterprise only, unset by default'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,9 @@ inputs:
   role:
     description: 'Vault role for specified auth method'
     required: false
-  path:
-    description: 'Custom Vault path, if the auth method was mounted at a different path'
+  auth_path:
+    description: 'Custom Vault auth path, if the auth method was mounted at a different path'
+    default: 'jwt-github-actions'
     required: false
   token:
     description: 'The Vault Token to be used to authenticate with Vault'

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
     required: false
   exportToken:
     description: 'Whether or not export Vault token as environment variables.'
-    default: 'false'
+    default: 'true'
     required: false
   outputToken:
     description: 'Whether or not to set the `vault_token` output to contain the Vault token after authentication.'

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   method:
     description: 'The method to use to authenticate with Vault.'
-    default: 'token'
+    default: 'jwt'
     required: false
   role:
     description: 'Vault role for specified auth method'

--- a/src/action.js
+++ b/src/action.js
@@ -10,14 +10,14 @@ const ENCODING_TYPES = ['base64', 'hex', 'utf8'];
 
 async function exportSecrets() {
     const vaultUrl = core.getInput('url', { required: true });
+    const secretsPath = core.getInput('path', { required: true });
     const vaultNamespace = core.getInput('namespace', { required: false });
     const extraHeaders = parseHeadersInput('extraHeaders', { required: false });
     const exportEnv = core.getInput('exportEnv', { required: false }) != 'false';
     const outputToken = (core.getInput('outputToken', { required: false }) || 'false').toLowerCase() != 'false';
     const exportToken = (core.getInput('exportToken', { required: false }) || 'false').toLowerCase() != 'false';
 
-    const secretsInput = core.getInput('secrets', { required: false });
-    const secretRequests = parseSecretsInput(secretsInput);
+    const secretRequests = parseSecretsInput(secretsPath);
 
     const secretEncodingType = core.getInput('secretEncodingType', { required: false });
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -11,7 +11,7 @@ const defaultKubernetesTokenPath = '/var/run/secrets/kubernetes.io/serviceaccoun
  * @param {import('got').Got} client
  */
 async function retrieveToken(method, client) {
-    let path = core.getInput('path', { required: false }) || method;
+    let path = core.getInput('auth_path', { required: false }) || method;
     path = `v1/auth/${path}/login`
 
     switch (method) {


### PR DESCRIPTION
# Changes

- rename input variable path to auth_path and set its default to `jwt-github-actions`
- rename input variable  secrets to path, which now expects a single path to the secret.
- set the default for auth method to `jwt`.